### PR TITLE
Fixing cart_paypal issue #23: Adaption to splitted ProcessOrderCreate…

### DIFF
--- a/Classes/Controller/Order/PaymentController.php
+++ b/Classes/Controller/Order/PaymentController.php
@@ -160,7 +160,7 @@ class PaymentController extends ActionController
                 $cancelEvent = new CancelEvent($this->cart->getCart(), $orderItem, $this->cartConf);
                 $this->eventDispatcher->dispatch($cancelEvent);
 
-                $this->redirect('show', 'Cart\Cart', 'Cart');
+                $this->redirect('show', 'Cart\Cart', 'Cart', ['cart' => $this->cart,'billingAddress' => $orderItem->getBillingAddress(), 'shippingAddress' => $orderItem->getShippingAddress()]);
             } else {
                 $this->addFlashMessage(
                     LocalizationUtility::translate(

--- a/Classes/EventListener/Order/Payment/ClearCart.php
+++ b/Classes/EventListener/Order/Payment/ClearCart.php
@@ -11,8 +11,17 @@ namespace Extcode\CartPaypal\EventListener\Order\Payment;
 
 use Extcode\Cart\Event\Order\EventInterface;
 
-class ClearCart extends \Extcode\Cart\EventListener\ProcessOrderCreate\ClearCart
+class ClearCart extends \Extcode\Cart\EventListener\Order\Finish\ClearCart
 {
+    public function __construct(
+        CartUtility $cartUtility,
+        ParserUtility $parserUtility,
+        SessionHandler $sessionHandler)
+    {
+        // call Grandpa's constructor
+        parent::__construct($cartUtility, $parserUtility, $sessionHandler);
+    }
+    
     public function __invoke(EventInterface $event): void
     {
         $orderItem = $event->getOrderItem();

--- a/Classes/EventListener/Order/Payment/ClearCart.php
+++ b/Classes/EventListener/Order/Payment/ClearCart.php
@@ -13,15 +13,6 @@ use Extcode\Cart\Event\Order\EventInterface;
 
 class ClearCart extends \Extcode\Cart\EventListener\Order\Finish\ClearCart
 {
-    public function __construct(
-        CartUtility $cartUtility,
-        ParserUtility $parserUtility,
-        SessionHandler $sessionHandler)
-    {
-        // call Grandpa's constructor
-        parent::__construct($cartUtility, $parserUtility, $sessionHandler);
-    }
-    
     public function __invoke(EventInterface $event): void
     {
         $orderItem = $event->getOrderItem();

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -38,9 +38,9 @@ services:
         identifier: 'cart-paypal--order--payment--provider-redirect'
         event: Extcode\Cart\Event\Order\PaymentEvent
 
-  Extcode\CartPaypal\EventListener\Order\Notify\Email:
+  Extcode\Cart\EventListener\Order\Finish\Email:
     class: 'Extcode\Cart\EventListener\Order\Finish\Email'
     tags:
       - name: event.listener
-        identifier: 'cart-paypal--order--notify--email'
-        event: Extcode\CartPaypal\Event\Order\NotifyEvent
+        identifier: 'cart-paypal--order--success--email'
+        event: Extcode\CartPaypal\Event\Order\SuccessEvent

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -38,9 +38,10 @@ services:
         identifier: 'cart-paypal--order--payment--provider-redirect'
         event: Extcode\Cart\Event\Order\PaymentEvent
 
-  Extcode\Cart\EventListener\Order\Finish\Email:
+  Extcode\CartPaypal\EventListener\Order\Notify\Email:
     class: 'Extcode\Cart\EventListener\Order\Finish\Email'
     tags:
       - name: event.listener
-        identifier: 'cart-paypal--order--success--email'
-        event: Extcode\CartPaypal\Event\Order\SuccessEvent
+        identifier: 'cart-paypal--order--notify--email'
+        event: Extcode\CartPaypal\Event\Order\NotifyEvent
+

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -17,6 +17,10 @@ services:
       $paymentRepository: '@Extcode\Cart\Domain\Repository\Order\PaymentRepository'
 
   Extcode\CartPaypal\EventListener\Order\Payment\ClearCart:
+    arguments:
+      $cartUtility: '@Extcode\Cart\Utility\CartUtility'
+      $parserUtility: '@Extcode\Cart\Utility\ParserUtility'
+      $sessionHandler: '@Extcode\Cart\Service\SessionHandler'
     tags:
       - name: event.listener
         identifier: 'cart-paypal--order--payment--clear-cart'
@@ -35,7 +39,7 @@ services:
         event: Extcode\Cart\Event\Order\PaymentEvent
 
   Extcode\CartPaypal\EventListener\Order\Notify\Email:
-    class: 'Extcode\Cart\EventListener\ProcessOrderCreate\Email'
+    class: 'Extcode\Cart\EventListener\Order\Finish\Email'
     tags:
       - name: event.listener
         identifier: 'cart-paypal--order--notify--email'


### PR DESCRIPTION
#23 This should fix the issue that I've created a couple of days ago. It corrects the adaptions to the splitted event of the cart extension