### PR TITLE
Add additional provider PAYPAL_CREDIT_CARD

### DIFF
--- a/Classes/EventListener/Order/Payment/ClearCart.php
+++ b/Classes/EventListener/Order/Payment/ClearCart.php
@@ -19,7 +19,7 @@ class ClearCart extends \Extcode\Cart\EventListener\ProcessOrderCreate\ClearCart
 
         $provider = $orderItem->getPayment()->getProvider();
 
-        if (strpos($provider, 'PAYPAL') === 0) {
+        if ((strpos($provider, 'PAYPAL') === 0) || (strpos($provider, 'PAYPAL_CREDIT_CARD') === 0)) {
             parent::__invoke($event);
         }
     }

--- a/Classes/EventListener/Order/Payment/ProviderRedirect.php
+++ b/Classes/EventListener/Order/Payment/ProviderRedirect.php
@@ -20,6 +20,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Extbase\Persistence\Generic\PersistenceManager;
+use TYPO3\CMS\Core\Log\LogManager;
 
 class ProviderRedirect
 {
@@ -85,6 +86,11 @@ class ProviderRedirect
      * @var array
      */
     protected $cartConf = [];
+    
+    /**
+     * @var logger
+     */
+    protected $logger;
 
     public function __construct(
         ConfigurationManager $configurationManager,
@@ -98,6 +104,8 @@ class ProviderRedirect
         $this->typoScriptService = $typoScriptService;
         $this->uriBuilder = $uriBuilder;
         $this->cartRepository = $cartRepository;
+
+        $this->logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
 
         $this->cartConf = $this->configurationManager->getConfiguration(
             ConfigurationManager::CONFIGURATION_TYPE_FRAMEWORK,
@@ -113,8 +121,8 @@ class ProviderRedirect
     public function __invoke(PaymentEvent $event): void
     {
         $this->orderItem = $event->getOrderItem();
-
-        if ($this->orderItem->getPayment()->getProvider() !== 'PAYPAL') {
+        if ($this->orderItem->getPayment()->getProvider() !== 'PAYPAL' &&
+            $this->orderItem->getPayment()->getProvider() !== 'PAYPAL_CREDIT_CARD') {
             return;
         }
 
@@ -177,6 +185,35 @@ class ProviderRedirect
         $this->paymentQuery['upload'] = '1';
 
         $this->paymentQuery['currency_code'] = $this->orderItem->getCurrencyCode();
+
+        if (strpos($this->orderItem->getPayment()->getProvider(), 'PAYPAL_CREDIT_CARD') === 0)
+           $this->paymentQuery['landing_page'] = 'billing';
+        
+        $selectedCountry = $this->orderItem->getBillingAddress()->getCountry();
+        foreach($this->cartPaypalConf['regionMappings'] as $locale => $countryMapping)
+        {
+            if (strpos($selectedCountry, $locale) === 0)
+            {
+                $localeAndCountryArray = explode(',', $countryMapping);
+                
+                $this->paymentQuery['lc'] = $localeAndCountryArray[1];
+                $this->paymentQuery['country_code'] = $localeAndCountryArray[0];
+                $this->logger->info("selected locale: " . $locale . " --> lc: " . $localeAndCountryArray[1] . ", country_code: " . $localeAndCountryArray[0]);
+            }
+        }
+        
+        if ($this->cartPaypalConf['logo'])
+        {
+            $site = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Site\SiteFinder::class)->getSiteByPageId((int)$this->cartConf['settings']['order']['pid']);
+            $logoUrl =  $site->getBase() . "/" . $this->cartPaypalConf['logo'];
+            $this->logger->info($logoUrl);
+            $this->paymentQuery['image_url'] = $logoUrl;
+        }
+        
+        if ($this->cartPaypalConf['displayShippingAddress'])
+            $this->paymentQuery['no_shipping'] = '0';
+        else
+            $this->paymentQuery['no_shipping'] = '1';
     }
 
     protected function getQueryFromCart(): void

--- a/Documentation/AdministratorManual/Configuration/Main/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/Main/Index.rst
@@ -16,11 +16,24 @@ The plugin needs to know the merchant e-mail address.
 ::
 
    plugin.tx_cartpaypal {
-       sandbox = 1
-       business = pp-wt-merchant@extco.de
-       debug = 1
+        sandbox = 1
+        business = pp-wt-merchant@extco.de
+        debug = 1
+        displayShippingAddress = 1
+        logo = fileadmin/cart/somelogo.png
+        regionMappings {
+            at = at,AT
+            de = de,DE
+            ch = ch,CH
+            be = be,BE
+            fr = fr,FR
+            it = it,IT
+            lu = lu,LU
+            nl = nl,NL
+            sk = sk,SK
+            si = si,SI
+        }
    }
-
 |
 
 .. container:: table-row
@@ -51,3 +64,34 @@ The plugin needs to know the merchant e-mail address.
          boolean
    Description
          Enables the logging for some debug messages.
+         
+.. container:: table-row
+
+   Property
+         plugin.tx_cartpaypal.displayShippingAddress
+   Data type
+         boolean
+   Description
+         Defines if Paypal shall display the shipping address form fields or not (Paypal variable no_shipping).
+
+.. container:: table-row
+
+   Property
+         plugin.tx_cartpaypal.logo
+   Data type
+         string
+   Description
+         Defines the path to a logo being displayed by Paypal. Supported formats are GIF, JPG, PNG with a max of 50KB and dimensions of max 750px width and 90px height.
+
+.. container:: table-row
+
+   Property
+         plugin.tx_cartpaypal.regionMappings
+   Data type
+         array
+   Description
+         Defines the country code and locale being pre-selected in Paypal according to the user-selected target shipment country
+         (e.g. user selects the Netherlands as target shipment country it makes sense to already pre-select nl,NL as country code and locale)
+         Left hand is the list of allowed countries as defined for tx_cart (plugin.tx_cart.settings.allowedCountries), right hand side is the combination of country code and locale as defined by Paypal)
+         Example: en = en,GB --> country code = en, locale = GB
+         In case no related regionMapping can be found, default bahvior of Paypal is used.

--- a/Documentation/AdministratorManual/Configuration/PaymentMethod/Index.rst
+++ b/Documentation/AdministratorManual/Configuration/PaymentMethod/Index.rst
@@ -18,10 +18,23 @@ from Cart available.
                    taxClassId = 1
                    status = open
                }
+               3 {
+                   provider = PAYPAL_CREDIT_CARD
+                   title = Credit Card
+                   extra = 0.00
+                   taxClassId = 1
+                   status = open
+               }
+               4 {
+                   provider = PAYPAL_CREDIT_CARD
+                   title = Direct Debit
+                   extra = 0.00
+                   taxClassId = 1
+                   status = open
+               }
            }
        }
    }
-
 |
 
 .. container:: table-row
@@ -31,6 +44,10 @@ from Cart available.
    Data type
       string
    Description
-      Defines that the payment provider for PayPal should be used.
-      This information is mandatory and ensures that the extension Cart PayPal takes control and for the authorization
-      of payment the user forwards to the PayPal site.
+      Defines that the payment provider for PayPal should be used. 
+      This information is mandatory and ensures that the extension Cart PayPal takes control for the authorization
+      of the payment and the user is forwarded to the PayPal site.
+      The provider 'PAYPAL' forwards to the classic paypal page and a Paypal account is necessary.
+      The provider 'PAYPAL_CREDIT_CARD' forwards to the billing page of Paypal allowing to pay with credit card and with direct debit.
+      Generally the user can reach these options from the classic Paypal page as well but it's beneficial to provide the options directly in the shop and forward the user to his preferred option.
+      However, take note that Cart Paypal cannot detect which payment option is finally used by the user - so please make sure to charge the same amount of fees for all Paypal payment options.


### PR DESCRIPTION
This pull request add a new provider PAYPAL_CREDIT_CARD to the extension allowing to forward directly to payment with credit card or direct debit without having a Paypal account.
Additionally some further configuration options have been added allowing some customization of the Paypal integration.
